### PR TITLE
Sort video and recording lists by creation time

### DIFF
--- a/storage/manager.py
+++ b/storage/manager.py
@@ -65,7 +65,7 @@ class StorageManager:
         self.strategy.cleanup(self.cat_videos_dir, max_size)
 
     def list_recordings(self) -> List[dict]:
-        """List all recordings with their metadata."""
+        """List all recordings with their metadata, sorted by creation time (newest first)."""
         recordings = []
         for file_path in self.recordings_dir.glob("*.mp4"):
             stat = file_path.stat()
@@ -75,10 +75,12 @@ class StorageManager:
                 "created": stat.st_mtime,
                 "path": str(file_path)
             })
+        # Sort by creation time, newest first
+        recordings.sort(key=lambda x: x["created"], reverse=True)
         return recordings
 
     def list_cat_videos(self) -> List[dict]:
-        """List all cat videos with their metadata."""
+        """List all cat videos with their metadata, sorted by creation time (newest first)."""
         cat_videos = []
         for file_path in self.cat_videos_dir.glob("*.mp4"):
             stat = file_path.stat()
@@ -88,6 +90,8 @@ class StorageManager:
                 "created": stat.st_mtime,
                 "path": str(file_path)
             })
+        # Sort by creation time, newest first
+        cat_videos.sort(key=lambda x: x["created"], reverse=True)
         return cat_videos
 
     def save_model(self, model_file: Path) -> Path:


### PR DESCRIPTION
- Modified list_cat_videos and list_recordings methods in StorageManager to sort videos and recordings by creation time (newest first)
- This change ensures that both cat videos and recordings are displayed in chronological order on the dashboard, with the most recent items appearing at the top of the list